### PR TITLE
feat: set run-from config

### DIFF
--- a/src/constant.ts
+++ b/src/constant.ts
@@ -15,6 +15,8 @@ export class Commands {
     `--${optionName}`
   static readonly NpmCi: string = 'npm ci'
   static readonly NpmInstall: string = 'npm install'
+  static readonly SetConfigRunFromAction: string =
+    'npx teamsfx config set run-from GitHubAction'
 }
 
 export class ErrorNames {

--- a/src/main.ts
+++ b/src/main.ts
@@ -23,6 +23,9 @@ async function run(): Promise<void> {
     ) {
       await Execute(Commands.NpmInstall)
     }
+    // Set run-from = GitHubAction before run cli.
+    await Execute(Commands.SetConfigRunFromAction)
+
     // Construct a command string from inputs.
     const commandString = BuildCommandString()
     await Execute(commandString)


### PR DESCRIPTION
Use `teamsfx config set run-from GitHubAction` to track cli's running context for this action.


Smoke test is passed.
