### PR TITLE
feat: add new option for env

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -11,6 +11,7 @@
       "eslint-comments/no-use": "off",
       "import/no-namespace": "off",
       "no-unused-vars": "off",
+      "filenames/match-regex": "off",
       "@typescript-eslint/no-unused-vars": "error",
       "@typescript-eslint/explicit-member-accessibility": ["error", {"accessibility": "no-public"}],
       "@typescript-eslint/no-require-imports": "error",

--- a/__tests__/commandBuilder.test.ts
+++ b/__tests__/commandBuilder.test.ts
@@ -115,4 +115,25 @@ describe('Test BuildCommandString', () => {
       )
     )
   })
+
+  test('Case 5: Specify Env', () => {
+    // Arrange
+    singleInputs = {
+      env: 'dev'
+    }
+
+    multipleInputs = {
+      commands: ['provision']
+    }
+
+    // Act
+    const cmdStr = BuildCommandString()
+
+    // Assert
+    expect(cmdStr).toBe(
+      [Commands.TeamsfxCliName, 'provision', '--env', 'dev'].join(
+        Commands.CommandSpace
+      )
+    )
+  })
 })

--- a/action.yml
+++ b/action.yml
@@ -63,6 +63,8 @@ inputs:
     description: 'Teams app endpoint.'
   root-path:
     description: 'Path to the setting files.'
+  env:
+    description: 'Select an existing environment for the project.'
 runs:
   using: 'node12'
   main: 'dist/index.js'

--- a/package.json
+++ b/package.json
@@ -42,6 +42,6 @@
     "js-yaml": "^3.14.0",
     "prettier": "2.2.1",
     "ts-jest": "^26.4.4",
-    "typescript": "^4.1.3"
+    "typescript": "^4.4.4"
   }
 }

--- a/src/enums/singleOptions.ts
+++ b/src/enums/singleOptions.ts
@@ -30,5 +30,6 @@ export enum SingleOptions {
   ApiVersion = 'api-version',
   Environment = 'environment',
   Endpoint = 'endpoint',
-  RootPath = 'root-path'
+  RootPath = 'root-path',
+  Env = 'env'
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,8 @@
     "strict": true,                           /* Enable all strict type-checking options. */
     "noImplicitAny": true,                    /* Raise error on expressions and declarations with an implied 'any' type. */
     "esModuleInterop": true,                   /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "useUnknownInCatchVariables": false,
   },
   "exclude": ["node_modules", "**/*.test.ts"]
 }


### PR DESCRIPTION
Add option support for multi-env along with:
1. eslint adjustment
2. upgrade typescript version
3. ut case
4. tsc compile option adjustment since upgrade

part of https://dev.azure.com/msazure/Microsoft%20Teams%20Extensibility/_workitems/edit/11808585